### PR TITLE
Don't depend on nightly + Clippy fixes

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,2 +1,2 @@
 // Characters to render.
-pub const ROFLCOPTER: [&'static str; 10] = ["R", "O", "F", "L", "C", "O", "P", "T", "E", "R"];
+pub const ROFLCOPTER: [&str; 10] = ["R", "O", "F", "L", "C", "O", "P", "T", "E", "R"];

--- a/src/enums/pathfinder.rs
+++ b/src/enums/pathfinder.rs
@@ -41,7 +41,7 @@ fn lazy_walker_fn(snake_game: &SnakeGame) -> Direction {
     }
 
     // At this point, we know that we need to change direction.
-    return if player_x_pos == snake_game.collectible_state.x_position {
+    if player_x_pos == snake_game.collectible_state.x_position {
         // Horizontally aligned, so we need to either go north or south.
         if player_y_pos < snake_game.collectible_state.y_position {
             Direction::South
@@ -55,7 +55,7 @@ fn lazy_walker_fn(snake_game: &SnakeGame) -> Direction {
         } else {
             Direction::West
         }
-    };
+    }
 }
 
 fn step_walker_fn(snake_game: &SnakeGame) -> Direction {
@@ -64,7 +64,7 @@ fn step_walker_fn(snake_game: &SnakeGame) -> Direction {
     let char_x_pos = snake_game.collectible_state.x_position;
     let char_y_pos = snake_game.collectible_state.y_position;
 
-    return if player_x_pos == char_x_pos {
+    if player_x_pos == char_x_pos {
         // The player is aligned horizontally, so just pick the correct vertical direction.
         get_optimal_direction(
             player_y_pos,
@@ -98,7 +98,7 @@ fn step_walker_fn(snake_game: &SnakeGame) -> Direction {
                 Plane::Vertical,
             ),
         }
-    };
+    }
 }
 
 /// Decides, whether traversal over the edge of the screen is quicker than line-of-sight direction.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(fs_try_exists)]
-
 mod collectible_state;
 mod constants;
 mod enums;

--- a/src/player_state.rs
+++ b/src/player_state.rs
@@ -41,11 +41,9 @@ impl PlayerState {
         self.player_parts[0].1 = pos;
     }
 
+    /// Draw all parts of the player.
     pub fn draw(&self, font_size: f32, color: Color) {
-        // Draw every player part. In order to know, which letter of ROFLCOPTER to draw per part,
-        // an index variable is used that increments after each draw.
-        let mut index = 0;
-        for player_part in self.player_parts.iter() {
+        for (index, player_part) in self.player_parts.iter().enumerate() {
             let abs_letter_x_pos = player_part.0 as f32 * font_size;
             let abs_letter_y_pos = player_part.1 as f32 * font_size;
 
@@ -56,8 +54,6 @@ impl PlayerState {
                 font_size,
                 color,
             );
-
-            index += 1;
         }
     }
 

--- a/src/snake_config.rs
+++ b/src/snake_config.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use std::{fs, path::Path};
 
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
@@ -23,16 +23,28 @@ pub struct SnakeConfig {
     pub draw_fps: bool,
 }
 
+impl Default for SnakeConfig {
+    fn default() -> Self {
+        Self {
+            instance_count: 100,
+            horizontal_slots: 80,
+            vertical_slots: 45,
+            move_interval: 0.05,
+            pathfinder: Pathfinder::LazyWalker,
+            starting_position: StartingPosition::Center,
+            draw_fps: false,
+        }
+    }
+}
+
 lazy_static! {
     pub static ref CONFIG: SnakeConfig = {
-        // Create the config from default, if it doesn't exist yet.
-        if !fs::try_exists("config.yaml").unwrap() {
-            fs::copy("config.default.yaml", "config.yaml").expect("Unable to initialize config.");
+        // Parse the config if it exist.
+        if Path::new("config.yaml").exists() {
+            let snake_config_yaml = fs::read_to_string("config.yaml").expect("Unable to read config.");
+            serde_yaml::from_str(snake_config_yaml.as_str()).expect("Unable to deserialize config.")
+        } else {
+            SnakeConfig::default()
         }
-
-        // Read the config.
-        let snake_config_yaml = fs::read_to_string("config.yaml").expect("Unable to read config.");
-
-        serde_yaml::from_str(snake_config_yaml.as_str()).unwrap()
     };
 }

--- a/src/snake_game_collection.rs
+++ b/src/snake_game_collection.rs
@@ -34,3 +34,9 @@ impl SnakeGameCollection {
         }
     }
 }
+
+impl Default for SnakeGameCollection {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
This MR removes the dependency on the `try_exists` feature flag, which requires the project to be built with the `nightly` toolchain.

While at it, it introduces a `Default` trait implementation for the configuration struct and fixes a few clippy lints :)